### PR TITLE
Improved indenting and syntax highlighting

### DIFF
--- a/indent/imba.vim
+++ b/indent/imba.vim
@@ -38,7 +38,7 @@ function ImbaIndent(lnum)
     return plindent - shiftwidth()
   endif
 
-  return -1
+  return plindent
 
 endfunction
 

--- a/indent/imba.vim
+++ b/indent/imba.vim
@@ -1,3 +1,5 @@
+" vim: sw=2
+
 if exists("b:did_indent")
   finish
 endif
@@ -16,9 +18,24 @@ function ImbaIndent(lnum)
   let pline = getline(plnum)
   let plindent = indent(plnum)
 
-  " Indent tag and function content
-  if pline =~ '^.*\<\(def\|tag\)\>'
-      return plindent + shiftwidth()
+  " Indent if previous line matches this
+  if pline =~ '^.*\<\(def\|tag\|class\|if\|else\|elif\|for\|while\|until\|switch\|case\|try\|catch\|finally\)\>'
+    return plindent + shiftwidth()
+  endif
+
+  " Deintent current line if it matches this
+  if getline(v:lnum) =~ '^\s*\(catch\|finally\|else\|elif\|when\)\>'
+    return indent(v:lnum) - shiftwidth()
+  endif
+
+  " Deintent line after return
+  if pline =~ '^\s*return\>'
+    return plindent - shiftwidth()
+  endif
+
+  " Deintet if second empty line
+  if getline(v:lnum - 1) =~ '^\s*$' && getline(v:lnum - 2) =~ '^\s*$'
+    return plindent - shiftwidth()
   endif
 
   return -1

--- a/indent/imba.vim
+++ b/indent/imba.vim
@@ -19,7 +19,7 @@ function ImbaIndent(lnum)
   let plindent = indent(plnum)
 
   " Indent if previous line matches this
-  if pline =~ '^.*\<\(def\|tag\|class\|if\|else\|elif\|for\|while\|until\|switch\|case\|try\|catch\|finally\)\>'
+  if pline =~ '^.*\<\(def\|tag\|class\|if\|else\|elif\|for\|while\|until\|switch\|case\|try\|catch\|finally\|do\)\>'
     return plindent + shiftwidth()
   endif
 

--- a/syntax/imba.vim
+++ b/syntax/imba.vim
@@ -20,14 +20,16 @@ endif
 syn keyword imbaBoolean true false yes no on off
 hi def link imbaBoolean Boolean
 
-syn keyword imbaKeyword import await typeof extends super yield new in self
+syn keyword imbaKeyword import await typeof extends super yield new in
 syn keyword imbaKeyword of by and or not is isnt isa var let tagdef expr
 
 syn match imbaMethod /\w\+/ display contained
-hi def link imbaMethod Structure
+hi def link imbaMethod Function
 
-syn keyword imbaKeyword def class tag prop nextgroup=imbaMethod skipwhite
-hi def link imbaKeyword Keyword
+syn keyword imbaKeyword def class tag nextgroup=imbaMethod skipwhite
+hi def link imbaKeyword Structure
+
+syn keyword Structure prop
 
 syn keyword imbaConditional if else elif unless switch then when 
 hi def link imbaConditional Conditional
@@ -40,9 +42,6 @@ hi def link imbaRepeat Repeat
 
 syn keyword imbaException try catch finally 
 hi def link imbaException Exception
-
-syn keyword imbaClass Math console
-hi def link imbaClass StorageClass
 
 syn keyword imbaFunction log warn
 syn keyword imbaFunction sin cos
@@ -82,7 +81,7 @@ hi def link imbaRegex Keyword
 syn match imbaSpecialOp /[,;]/ display
 hi def link imbaSpecialOp Delimiter
 
-syn match imbaSpecialVar /\<\%(this\|prototype\|arguments\)\>/ display
+syn keyword imbaSpecialVar this prototype arguments self Math console
 hi def link imbaSpecialVar Special
 
 syn match imbaSpecialIdent /@\%(\%(\I\|\$\)\%(\i\|\$\)*\)\?/ display

--- a/syntax/imba.vim
+++ b/syntax/imba.vim
@@ -76,7 +76,7 @@ syn match imbaExtendedOp /\%(\S\s*\)\@<=[+\-*/%&|\^=!<>?.]\{-1,}\|[-=]>\|--\|++\
 syn match imbaExtendedOp /\<\%(and\|or\)=/ display
 hi def link imbaExtendedOp imbaOperator
 
-syn region imbaRegex start=/\// end=/\// display
+syn region imbaRegex start=/\// end=/\// display oneline
 hi def link imbaRegex Keyword
 
 syn match imbaSpecialOp /[,;]/ display
@@ -103,7 +103,7 @@ hi def link imbaObjAssign Identifier
 
 syn match imbaTagValue "=[\t ]*" contained
 syn match imbaTags /\w+/ contained contains=imbaTagValue
-syn region Tag start=/</ end=/>/ contains=imbaTags
+syn region Tag start=/</ end=/>/ contains=imbaTags oneline
 
 " Error marking
 

--- a/syntax/imba.vim
+++ b/syntax/imba.vim
@@ -100,10 +100,18 @@ syn match imbaObjAssign /@\?\%(\I\|\$\)\%(\i\|\$\)*\s*\ze::\@!/ contains=@imbaId
 hi def link imbaObjAssign Identifier
 
 " Tags (html-like markup)
+" From http://stackoverflow.com/a/13620967 and html.vim
+syn match imbaTagAttributeName /\w\+=/he=e-1 contained
+syn match imbaTagAttribute contained "\w\+=[^"]\S\+" contains=imbaTagAttributeName,String,imbaBoolean,Variable
+syn region imbaTagAttribute contained start=+\w\+="+ skip=+\\\\\|\\"+ end=+"+ contains=imbaTagAttributeName,String,imbaBoolean,Variable keepend
+syn match imbaTagName /<\i\+/ contained contains=imbaTagStart
+syn region imbaTag start=/</ end=/>/ contains=imbaTagName,imbaTagAttribute oneline
+syn match imbaTagStart '<' contained
 
-syn match imbaTagValue "=[\t ]*" contained
-syn match imbaTags /\w+/ contained contains=imbaTagValue
-syn region Tag start=/</ end=/>/ contains=imbaTags oneline
+hi def link imbaTag Function
+hi def link imbaTagStart Function
+hi def link imbaTagName Statement
+hi def link imbaTagAttributeName Type
 
 " Error marking
 

--- a/syntax/imba.vim
+++ b/syntax/imba.vim
@@ -75,8 +75,9 @@ syn match imbaExtendedOp /\%(\S\s*\)\@<=[+\-*/%&|\^=!<>?.]\{-1,}\|[-=]>\|--\|++\
 syn match imbaExtendedOp /\<\%(and\|or\)=/ display
 hi def link imbaExtendedOp imbaOperator
 
-syn region imbaRegex start=/\// end=/\// display oneline
-hi def link imbaRegex Keyword
+" Regex-regex from javascript.vim
+syn region imbaRegex start=+/[^/*]+me=e-1 skip=+\\\\\|\\/+ end=+/[gim]\{0,2\}\s*$+ end=+/[gim]\{0,2\}\s*[;.,)\]}]+me=e-1 oneline
+hi def link imbaRegex String
 
 syn match imbaSpecialOp /[,;]/ display
 hi def link imbaSpecialOp Delimiter
@@ -104,7 +105,7 @@ syn match imbaTagAttributeName /\w\+=/he=e-1 contained
 syn match imbaTagAttribute contained "\w\+=[^"]\S\+" contains=imbaTagAttributeName,String,imbaBoolean,Variable
 syn region imbaTagAttribute contained start=+\w\+="+ skip=+\\\\\|\\"+ end=+"+ contains=imbaTagAttributeName,String,imbaBoolean,Variable keepend
 syn match imbaTagName /<\i\+/ contained contains=imbaTagStart
-syn region imbaTag start=/</ end=/>/ contains=imbaTagName,imbaTagAttribute oneline
+syn region imbaTag start=/<\w\+/ end=/>/ contains=imbaTagName,imbaTagAttribute
 syn match imbaTagStart '<' contained
 
 hi def link imbaTag Function
@@ -116,6 +117,9 @@ hi def link imbaTagAttributeName Type
 
 syn match imbaSemicolonError /;$/ display
 hi def link imbaSemicolonError Error
+
+syn match imbaWrongComment /^\s*\/\/.*$/ display
+hi def link imbaWrongComment Error
 
 " Cleanup
 

--- a/test/indent.vroom
+++ b/test/indent.vroom
@@ -27,3 +27,29 @@ Make sure tags get properly indented
   &
     def render
       let martin = 'best'
+  @clear
+
+Make sure ifs get amazingly indented
+  :set ft=imba
+  > i
+  |if martin == 'awesome'<CR>
+  |self.dootdoot<CR>
+  |else<CR>
+  |self.playMusic verySadMusic<Esc>
+  if martin == 'awesome'
+    self.dootdoot
+  else
+    self.playMusic verySadMusic
+  @clear
+
+Make sure the line after two empty lines is deintented
+  :set ft=imba
+  > i
+  |  def run<CR>oioi<CR><CR><CR>awdawd<Esc>
+    def run
+      oioi
+  &
+  &
+    awdawd
+  @clear
+


### PR DESCRIPTION
I improved the indenting rules so they are much smarter now and the syntax highlighting now does the HTML-like Imba tags.

The last commit makes the colors look more like vim's Javascript syntax highlighting. I haven't really looked into vim-coffee-script, so it might differ a bit.
